### PR TITLE
#137423955 Launch Container in Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ target/
 # External Libraries 
 wger/core/static/bower_components
 node_modules
+
+# Mac .DS_Store files
+.DS_Store

--- a/extras/docker/apache/Dockerfile
+++ b/extras/docker/apache/Dockerfile
@@ -2,14 +2,14 @@
 # A wger installation under apache with WSGI
 #
 # Please consult the documentation for usage
-# docker build --tag wger/apache .
-# docker run -ti --name wger.apache --publish 8000:80 wger/apache
+# docker build --tag asgards254/apache .
+# docker run -ti --name asgards254.apache --publish 8000:80 asgards254/apache
 #
 #
 
-FROM wger/base
+FROM asgards254/base
 
-MAINTAINER Roland Geider <roland@geider.net>
+MAINTAINER Andela Asgards <asgards@andela.com>
 EXPOSE 80
 
 # Install dependencies
@@ -22,7 +22,7 @@ RUN a2ensite wger
 
 # Set up the application
 USER wger
-RUN git clone https://github.com/wger-project/wger.git /home/wger/src
+RUN git clone https://github.com/andela/wger_asgards.git /home/wger/src
 
 WORKDIR /home/wger/src
 RUN virtualenv --python python3 /home/wger/venv

--- a/extras/docker/apache/README.md
+++ b/extras/docker/apache/README.md
@@ -16,7 +16,7 @@ process under apache with a sqlite database. It is useful to just try it out and
 play around. To start it:
 
 
-```docker run -ti --name wger.apache --publish 8000:80 wger/apache```
+```docker run -ti --name asgards254.apache --publish 8000:80 asgards254/apache```
 
 Then just open http://localhost:8000 and log in as: **admin**, password **admin**
 

--- a/extras/docker/base/Dockerfile
+++ b/extras/docker/base/Dockerfile
@@ -5,12 +5,12 @@
 # This dockerfile simply installs all common dependencies for the
 # other images and does not do anything on its own.
 #
-# docker build --tag wger/base .
+# docker build --tag asgards254/base .
 #
 
 FROM ubuntu:16.04
 
-MAINTAINER Roland Geider <roland@geider.net>
+MAINTAINER Andela Asgards <asgards@andela.com>
 
 # Install dependencies
 RUN apt-get update;\

--- a/extras/docker/base/README.md
+++ b/extras/docker/base/README.md
@@ -3,7 +3,7 @@ Development image for wger - Base image
 This is the base image for some of the other wger images and offers no
 functionality, it's only use is to provide some common dependencies.
 
-If you want to develop, try either ``wger/devel`` oder ``wger/devel-fedora``.
+If you want to develop, try either ``asgards254/devel`` or ``asgards254/devel-fedora``.
 
 
 Contact

--- a/extras/docker/development-fedora/Dockerfile
+++ b/extras/docker/development-fedora/Dockerfile
@@ -2,14 +2,14 @@
 # Docker image for wger development on a fedora base image
 #
 # Please consult the documentation for usage
-# docker build -t wger/devel-fedora .
-# docker run -ti --name wger.devel-fedora --publish 8000:8000 wger/devel-fedora
+# docker build -t asgards254/devel-fedora .
+# docker run -ti --name asgards254.devel-fedora --publish 8000:8000 asgards254/devel-fedora
 # (in docker) source ~/venv/bin/activate
 # (in docker) python manage.py runserver 0.0.0.0:8000
 #
 #
 FROM fedora:24
-MAINTAINER Roland Geider <roland@geider.net>
+MAINTAINER Andela Asgards <asgards@andela.com>
 
 # Install dependencies
 RUN dnf update;\
@@ -25,7 +25,7 @@ EXPOSE 8000
 
 # Set up the application
 USER wger
-RUN git clone https://github.com/wger-project/wger.git /home/wger/src
+RUN git clone https://github.com/andela/wger_asgards.git /home/wger/src
 
 WORKDIR /home/wger/src
 RUN virtualenv --python python3 /home/wger/venv

--- a/extras/docker/development-fedora/README.md
+++ b/extras/docker/development-fedora/README.md
@@ -15,7 +15,7 @@ This docker image contains an instance of the application running with django's
 development server using a sqlite database. It can be used to quickly setup a
 development instance (vim and tmux are already installed):
 
-```docker run -ti --name wger.devel-fedora --publish 8000:8000 wger/devel-fedora```
+```docker run -ti --name asgards254.devel-fedora --publish 8000:8000 asgards254/devel-fedora```
 
 Then, *within the docker image*, activate the virtualenv
 

--- a/extras/docker/development/Dockerfile
+++ b/extras/docker/development/Dockerfile
@@ -2,17 +2,17 @@
 # Docker image for wger development
 #
 # Please consult the documentation for usage
-# docker build -t wger/devel .
-# docker run -ti --name wger.devel --publish 8000:8000 wger/devel
+# docker build -t asgards254/devel .
+# docker run -ti --name asgards254.devel --publish 8000:8000 asgards254/devel
 # (in docker) source ~/venv/bin/activate
 # (in docker) python manage.py runserver 0.0.0.0:8000
 #
 #
 
 
-FROM wger/base
+FROM asgards254/base
 
-MAINTAINER Roland Geider <roland@geider.net>
+MAINTAINER Andela Asgards <asgards@andela.com>
 EXPOSE 8000
 
 # Install dependencies
@@ -20,7 +20,7 @@ RUN apt-get install -y vim tmux sqlite3
 
 # Set up the application
 USER wger
-RUN git clone https://github.com/wger-project/wger.git /home/wger/src
+RUN git clone https://github.com/andela/wger_asgards.git /home/wger/src
 
 WORKDIR /home/wger/src
 RUN virtualenv --python python3 /home/wger/venv

--- a/extras/docker/development/README.md
+++ b/extras/docker/development/README.md
@@ -15,7 +15,7 @@ This docker image contains an instance of the application running with django's
 development server using a sqlite database. It can be used to quickly setup a
 development instance (vim and tmux are already installed):
 
-```docker run -ti --name wger.devel --publish 8000:8000 wger/devel```
+```docker run -ti --name asgards254.devel --publish 8000:8000 asgards254/devel```
 
 Then, *within the docker image*, activate the virtualenv
 


### PR DESCRIPTION
#### What does this PR do?

Modify the Docker image building process to point to `wger_asgards` repo instead of the original `wger` project.
Change the relevant README instructions to use `asgards254` Docker Hub Images when running the images.

#### Description of Task to be completed?

- Modify the all the Dockerfiles to build all the images using `wger_asgards` Github repo.
- Modify the all the READMEs with new instructions on how to run the images.
- Build the images and push them to the Docker Hub Registry.

#### How should this be manually tested?

To test this manually, run the following command:

```docker run -ti --name asgards254.devel --publish 8000:8000 asgards254/devel```

Then, *within the docker image*, activate the virtualenv

```source ~/venv/bin/activate```

run the tests using the following command

```python manage.py test```

finally, start the development server

```python manage.py runserver 0.0.0.0:8000```

Then just open http://localhost:8000 and log in as: **admin**, password **admin**

#### What are the relevant pivotal tracker stories?

#137423955