### PR TITLE
#137085739 Present Deactivated Users in Gym Overview

### DIFF
--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -15,6 +15,30 @@
 
 {% block content %}
 {% if perms.gym.manage_gym or perms.gym.gym_trainer %}
+    <div id="userfilter" class="col-sm-8">
+        {% block userfilter %}
+            {% if perms.gym.change_gym %}
+                <div class="btn-group pull-left">
+                    <button type="button" class="btn btn-default dropdown-toggle btn-xs" data-toggle="dropdown">
+                        {% if inactive == '0' %}
+                            {% trans "Active Users" %}
+                        {% else %}
+                            {% trans "Inactive Users" %}
+                        {% endif %}
+                        <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu" role="menu">
+                        <li>
+                            <a href="/en/gym/{{gym.id}}/members">Active Users</a>
+                        </li>
+                        <li>
+                            <a href="/en/gym/{{gym.id}}/members?inactive=1">Inactive Users</a>
+                        </li>
+                    </ul>
+                </div>
+            {% endif %}
+        {% endblock %}
+    </div>
     {% include 'gym/partial_user_list.html' %}
 {% endif %}
 

--- a/wger/gym/templates/gym/partial_user_list.html
+++ b/wger/gym/templates/gym/partial_user_list.html
@@ -24,31 +24,63 @@ $(document).ready( function () {
 </thead>
 <tbody>
 {% for current_user in user_table.users %}
-<tr>
-    <td>
-        {{current_user.obj.pk}}
-    </td>
-    <td>
-        <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
-    </td>
-    <td>
-        {{current_user.obj.get_full_name}}
-    </td>
-    <td data-order="{{current_user.last_log|date:'U'}}">
-        {{current_user.last_log|default:'-/-'}}
-    </td>
-    {% if show_gym %}
-    <td>
-        {% if current_user.obj.userprofile.gym_id %}
-            <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
-            {{ current_user.obj.userprofile.gym }}
-            </a>
-        {% else %}
-            -/-
-        {% endif %}
-    </td>
+{% if inactive == '0' %}
+    {% if current_user.obj.is_active %}
+        <tr>
+            <td>
+                {{current_user.obj.pk}}
+            </td>
+            <td>
+                <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+            </td>
+            <td>
+                {{current_user.obj.get_full_name}}
+            </td>
+            <td data-order="{{current_user.last_log|date:'U'}}">
+                {{current_user.last_log|default:'-/-'}}
+            </td>
+            {% if show_gym %}
+            <td>
+                {% if current_user.obj.userprofile.gym_id %}
+                    <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
+                    {{ current_user.obj.userprofile.gym }}
+                    </a>
+                {% else %}
+                    -/-
+                {% endif %}
+            </td>
+            {% endif %}
+        </tr>
     {% endif %}
-</tr>
+{% elif inactive == '1' %}
+    {% if not current_user.obj.is_active %}
+        <tr>
+            <td>
+                {{current_user.obj.pk}}
+            </td>
+            <td>
+                <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+            </td>
+            <td>
+                {{current_user.obj.get_full_name}}
+            </td>
+            <td data-order="{{current_user.last_log|date:'U'}}">
+                {{current_user.last_log|default:'-/-'}}
+            </td>
+            {% if show_gym %}
+            <td>
+                {% if current_user.obj.userprofile.gym_id %}
+                    <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
+                    {{ current_user.obj.userprofile.gym }}
+                    </a>
+                {% else %}
+                    -/-
+                {% endif %}
+            </td>
+            {% endif %}
+        </tr>
+    {% endif %}
+{% endif %}
 {% endfor %}
 </tbody>
 </table>

--- a/wger/gym/views/gym.py
+++ b/wger/gym/views/gym.py
@@ -129,6 +129,7 @@ class GymUserListView(LoginRequiredMixin, WgerMultiplePermissionRequiredMixin, L
         context['user_count'] = len(context['object_list']['members'])
         context['user_table'] = {'keys': [_('ID'), _('Username'), _('Name'), _('Last activity')],
                                  'users': context['object_list']['members']}
+        context['inactive'] = self.inactive
         return context
 
 

--- a/wger/gym/views/gym.py
+++ b/wger/gym/views/gym.py
@@ -90,7 +90,6 @@ class GymUserListView(LoginRequiredMixin, WgerMultiplePermissionRequiredMixin, L
         '''
         Only managers and trainers for this gym can access the members
         '''
-        self.inactive = request.GET.get('inactive') or '0'
         if request.user.has_perm('gym.manage_gyms') \
             or ((request.user.has_perm('gym.manage_gym')
                 or request.user.has_perm('gym.gym_trainer'))
@@ -129,7 +128,7 @@ class GymUserListView(LoginRequiredMixin, WgerMultiplePermissionRequiredMixin, L
         context['user_count'] = len(context['object_list']['members'])
         context['user_table'] = {'keys': [_('ID'), _('Username'), _('Name'), _('Last activity')],
                                  'users': context['object_list']['members']}
-        context['inactive'] = self.inactive
+        context['inactive'] = self.request.GET.get('inactive', '0')
         return context
 
 

--- a/wger/gym/views/gym.py
+++ b/wger/gym/views/gym.py
@@ -90,6 +90,7 @@ class GymUserListView(LoginRequiredMixin, WgerMultiplePermissionRequiredMixin, L
         '''
         Only managers and trainers for this gym can access the members
         '''
+        self.inactive = request.GET.get('inactive') or '0'
         if request.user.has_perm('gym.manage_gyms') \
             or ((request.user.has_perm('gym.manage_gym')
                 or request.user.has_perm('gym.gym_trainer'))


### PR DESCRIPTION
#### What does this PR do?

This PR provides a way of viewing activated and deactivated users in the Gym overview by adding a dropdown menu that allows a user to select the status of users he/she wants to view.

#### Description of Task to be completed?
- Edit the gym view to accept a query paremeter named 'inactive' which can either be 0 or 1 on the gym overview route

- Add a context named 'inactive' in the gym view

- Add some logic to the partial user list template to handle the dynamic showing of active and inactive users

- Edit the member list template to add a dropdown menu that will handle the switching between active and inactive users

#### How should this be manually tested?

To test this manually, run the following command:

```python manage.py test wger.gym```

#### What are the relevant pivotal tracker stories?

#137085739